### PR TITLE
Invalid item id's being passed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.7'
+def runeLiteVersion = '1.8.25'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/patchpayment/PatchPaymentConfig.java
+++ b/src/main/java/com/patchpayment/PatchPaymentConfig.java
@@ -4,13 +4,11 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-import java.util.Locale;
 
-@ConfigGroup("patchpayment")
+@ConfigGroup(PatchPaymentPlugin.CONFIG_GROUP)
 public interface PatchPaymentConfig extends Config {
-
 	@ConfigItem(
-			keyName = "examinetext",
+			keyName = PatchPaymentPlugin.CHECK_EXAMINE,
 			name = "Check Payment With Examine",
 			description = "Examine an item to see what the payment is and remove the 'Check' menu option.",
 			position = 1
@@ -18,7 +16,7 @@ public interface PatchPaymentConfig extends Config {
 	default boolean checkWithExamine() { return false; }
 
 	@ConfigItem(
-			keyName = "bankmenuitem",
+			keyName = PatchPaymentPlugin.CHECK_BANK,
 			name = "Enable Check in Bank",
 			description = "Enables the ability to check payments while in the bank interface.",
 			position = 2
@@ -26,7 +24,7 @@ public interface PatchPaymentConfig extends Config {
 	default boolean checkInBank() { return false; }
 
 	@ConfigItem(
-			keyName = "seedvaultitem",
+			keyName = PatchPaymentPlugin.CHECK_VAULT,
 			name = "Enable Check in Seed Vault",
 			description = "Enables the ability to check payments while in the seed vault interface.",
 			position = 3

--- a/src/main/java/com/patchpayment/PatchPaymentPlugin.java
+++ b/src/main/java/com/patchpayment/PatchPaymentPlugin.java
@@ -1,5 +1,6 @@
 package com.patchpayment;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +20,8 @@ import net.runelite.client.plugins.PluginDescriptor;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static net.runelite.api.ItemID.*;
 
@@ -37,74 +39,86 @@ public class PatchPaymentPlugin extends Plugin {
     static final String CHECK_BANK = "bankmenuitem";
     static final String CHECK_VAULT = "seedvaultitem";
     private static final String CHECK_PAYMENT = "Check";
-    private static final String TAGS_MENU_REMOVE = "Remove";
-    private static final String TAGS_MENU_SET = "Mark";
+    private static final String EXAMINE = "Examine";
 
-    private final PairInterface[] paymentPairList = {
-            // ALLOTMENT PAIRS
-            new PaymentPair("2 buckets of compost", new int[]{POTATO_SEED}),
-            new PaymentPair("1 full sack of potatoes", new int[]{ONION_SEED}),
-            new PaymentPair("1 full sack of onions", new int[]{CABBAGE_SEED}),
-            new PaymentPair("2 full sacks of cabbages", new int[]{TOMATO_SEED}),
-            new PaymentPair("10 jute fibres", new int[]{SWEETCORN_SEED}),
-            new PaymentPair("1 full basket of apples", new int[]{STRAWBERRY_SEED}),
-            new PaymentPair("10 curry leaves", new int[]{WATERMELON_SEED}),
-            new PaymentPair("5 jangerberries", new int[]{SNAPE_GRASS_SEED}),
-            // FLOWER SEEDS
-            new CustomPair(new int[]{MARIGOLD_SEED, ROSEMARY_SEED, NASTURTIUM_SEED, WOAD_SEED, LIMPWURT_SEED, WHITE_LILY_SEED}),
-            // HERB PAIRS
-            new CustomPair(new int[]{GUAM_SEED, MARRENTILL_SEED, TARROMIN_SEED, HARRALANDER_SEED, GOUT_TUBER, RANARR_SEED, TOADFLAX_SEED, IRIT_SEED, AVANTOE_SEED, KWUARM_SEED, SNAPDRAGON_SEED, CADANTINE_SEED, LANTADYME_SEED, DWARF_WEED_SEED, TORSTOL_SEED}),
-            // HOPS PAIRS
-            new PaymentPair("3 buckets of compost", new int[]{BARLEY_SEED}),
-            new PaymentPair("1 marigold", new int[]{HAMMERSTONE_SEED}, "hammerstone hops"),
-            new PaymentPair("1 full sack of onions", new int[]{ASGARNIAN_SEED}, "asgarnian hops"),
-            new PaymentPair("6 barley malts", new int[]{JUTE_SEED}),
-            new PaymentPair("1 full basket of tomatoes", new int[]{YANILLIAN_SEED}, "yanillian hops"),
-            new PaymentPair("3 full sacks of cabbages", new int[]{KRANDORIAN_SEED}, "krandorian hops"),
-            new PaymentPair("1 nasturtium", new int[]{WILDBLOOD_SEED}),
-            // BUSH PAIRS
-            new PaymentPair("4 full sacks of cabbages", new int[]{REDBERRY_SEED}),
-            new PaymentPair("3 full baskets of tomatoes", new int[]{CADAVABERRY_SEED}),
-            new PaymentPair("3 full baskets of strawberries", new int[]{DWELLBERRY_SEED}),
-            new PaymentPair("6 watermelons", new int[]{JANGERBERRY_SEED}),
-            new PaymentPair("8 bittercap mushrooms", new int[]{WHITEBERRY_SEED}),
-            new CustomPair("as it will never get diseased", new int[]{POISON_IVY_SEED}),
-            // TREE PAIRS
-            new PaymentPair("1 full basket of tomatoes", new int[]{ACORN, OAK_SAPLING, OAK_SEEDLING, OAK_SEEDLING_W}, "oak tree"),
-            new PaymentPair("1 full basket of apples", new int[]{WILLOW_SEED, WILLOW_SAPLING, WILLOW_SEEDLING, WILLOW_SEEDLING_W}, "willow tree"),
-            new PaymentPair("1 full basket of oranges", new int[]{MAPLE_SEED, MAPLE_SAPLING, MAPLE_SEEDLING, MAPLE_SEEDLING_W}, "maple tree"),
-            new PaymentPair("10 cactus spines", new int[]{YEW_SEED, YEW_SAPLING, YEW_SEEDLING, YEW_SEEDLING_W}, "yew tree"),
-            new PaymentPair("25 coconuts", new int[]{MAGIC_SEED, MAGIC_SAPLING, MAGIC_SEEDLING, MAGIC_SEEDLING_W}, "magic tree"),
-            // FRUIT TREE PAIRS
-            new PaymentPair("9 sweetcorn", new int[]{APPLE_TREE_SEED, APPLE_SAPLING, APPLE_SEEDLING, APPLE_SEEDLING_W}, "apple tree"),
-            new PaymentPair("4 full baskets of apples", new int[]{BANANA_TREE_SEED, BANANA_SAPLING, BANANA_SEEDLING, BANANA_SEEDLING_W}, "banana tree"),
-            new PaymentPair("3 full baskets of strawberries", new int[]{ORANGE_TREE_SEED, ORANGE_SAPLING, ORANGE_SEEDLING, ORANGE_SEEDLING_W}, "orange tree"),
-            new PaymentPair("5 full baskets of bananas", new int[]{CURRY_TREE_SEED, CURRY_SAPLING, CURRY_SEEDLING, CURRY_SEEDLING_W}, "curry tree"),
-            new PaymentPair("10 watermelons", new int[]{PINEAPPLE_SEED, PINEAPPLE_SAPLING, PINEAPPLE_SEEDLING, PINEAPPLE_SEEDLING_W}),
-            new PaymentPair("10 pineapples", new int[]{PAPAYA_TREE_SEED, PAPAYA_SAPLING, PAPAYA_SEEDLING, PAPAYA_SEEDLING_W}, "papaya tree"),
-            new PaymentPair("15 papaya fruit", new int[]{PALM_TREE_SEED, PALM_SAPLING, PALM_SEEDLING, PALM_SEEDLING_W}, "palm tree"),
-            new PaymentPair("15 coconuts", new int[]{DRAGONFRUIT_TREE_SEED, DRAGONFRUIT_SAPLING, DRAGONFRUIT_SEEDLING, DRAGONFRUIT_SEEDLING_W}, "dragonfruit tree"),
-            // SPECIAL PAIRS
-            new PaymentPair("200 numulite", new int[]{SEAWEED_SPORE}),
-            new CustomPair("as it is protected for free. That doesn't make sense but I'm too lazy to change it", new int[]{GRAPE_SEED}),
-            new CustomPair(new int[]{MUSHROOM_SPORE, BELLADONNA_SEED}),
-            new CustomPair("as it is immune to disease", new int[]{HESPORI_SEED}),
-            // ANIMA PAIRS
-            new CustomPair(new int[]{KRONOS_SEED, IASOR_SEED, ATTAS_SEED}),
-            // SPECIAL TREE PAIRS
-            new PaymentPair("15 limpwurt roots", new int[]{TEAK_SEED, TEAK_SAPLING, TEAK_SEEDLING, TEAK_SEEDLING_W}, "teak tree"),
-            new PaymentPair("25 yanillian hops", new int[]{MAHOGANY_SEED, MAHOGANY_SAPLING, MAHOGANY_SEEDLING, MAHOGANY_SEEDLING_W}, "mahogany tree"),
-            new PaymentPair("8 poison ivy berries", new int[]{CALQUAT_TREE_SEED, CALQUAT_SAPLING, CALQUAT_SEEDLING, CALQUAT_SEEDLING_W}, "calquat tree"),
-            new CustomPair("as it is immune to disease", new int[]{CRYSTAL_SEED, CRYSTAL_SAPLING, CRYSTAL_SEEDLING, CRYSTAL_SEEDLING_W}),
-            new PaymentPair("5 monkey nuts, 1 monkey bar, and 1 ground tooth", new int[]{SPIRIT_SEED, SPIRIT_SAPLING, SPIRIT_SEEDLING, SPIRIT_SEEDLING_W}, "spirit tree"),
-            new PaymentPair("8 potato cacti", new int[]{CELASTRUS_SEED, CELASTRUS_SAPLING, CELASTRUS_SEEDLING, CELASTRUS_SEEDLING_W}, "celastrus tree"),
-            new PaymentPair("6 dragonfruit", new int[]{REDWOOD_TREE_SEED, REDWOOD_SAPLING, REDWOOD_SEEDLING, REDWOOD_SEEDLING_W}, "redwood tree"),
-            // CACTI PAIRS
-            new PaymentPair("6 cadava berries", new int[]{CACTUS_SEED}),
-            new PaymentPair("8 snape grass", new int[]{POTATO_CACTUS_SEED})
-    };
+    private static final Map<Integer, PairInterface> payments;
 
-    private final HashSet<Integer> acceptedWidgetIds = Sets.newHashSet();
+    private final Set<Integer> acceptedWidgetIds = Sets.newHashSet();
+
+    private static void add(ImmutableMap.Builder<Integer, PairInterface> builder, PairInterface response)
+    {
+        for(int id : response.getTargetItems())
+        {
+            builder.put(id, response);
+        }
+    }
+
+    static {
+        ImmutableMap.Builder<Integer, PairInterface> builder = new ImmutableMap.Builder<>();
+
+        add(builder, new PaymentPair("2 buckets of compost", new int[] {POTATO_SEED}));
+        add(builder, new PaymentPair("1 full sack of potatoes", new int[] {ONION_SEED}));
+        add(builder, new PaymentPair("1 full sack of onions", new int[] {CABBAGE_SEED}));
+        add(builder, new PaymentPair("2 full sacks of cabbages", new int[] {TOMATO_SEED}));
+        add(builder, new PaymentPair("10 jute fibres", new int[] {SWEETCORN_SEED}));
+        add(builder, new PaymentPair("1 full basket of apples", new int[] {STRAWBERRY_SEED}));
+        add(builder, new PaymentPair("10 curry leaves", new int[] {WATERMELON_SEED}));
+        add(builder, new PaymentPair("5 jangerberries", new int[] {SNAPE_GRASS_SEED}));
+        // FLOWER SEEDS
+        add(builder, new CustomPair(new int[] {MARIGOLD_SEED, ROSEMARY_SEED, NASTURTIUM_SEED, WOAD_SEED, LIMPWURT_SEED, WHITE_LILY_SEED}));
+        // HERB PAIRS
+        add(builder, new CustomPair(new int[] {GUAM_SEED, MARRENTILL_SEED, TARROMIN_SEED, HARRALANDER_SEED, GOUT_TUBER, RANARR_SEED, TOADFLAX_SEED, IRIT_SEED, AVANTOE_SEED, KWUARM_SEED, SNAPDRAGON_SEED, CADANTINE_SEED, LANTADYME_SEED, DWARF_WEED_SEED, TORSTOL_SEED}));
+        // HOPS PAIRS
+        add(builder, new PaymentPair("3 buckets of compost", new int[] {BARLEY_SEED}));
+        add(builder, new PaymentPair("1 marigold", new int[] {HAMMERSTONE_SEED}, "hammerstone hops"));
+        add(builder, new PaymentPair("1 full sack of onions", new int[] {ASGARNIAN_SEED}, "asgarnian hops"));
+        add(builder, new PaymentPair("6 barley malts", new int[] {JUTE_SEED}));
+        add(builder, new PaymentPair("1 full basket of tomatoes", new int[] {YANILLIAN_SEED}, "yanillian hops"));
+        add(builder, new PaymentPair("3 full sacks of cabbages", new int[] {KRANDORIAN_SEED}, "krandorian hops"));
+        add(builder, new PaymentPair("1 nasturtium", new int[] {WILDBLOOD_SEED}));
+        // BUSH PAIRS
+        add(builder, new PaymentPair("4 full sacks of cabbages", new int[] {REDBERRY_SEED}));
+        add(builder, new PaymentPair("3 full baskets of tomatoes", new int[] {CADAVABERRY_SEED}));
+        add(builder, new PaymentPair("3 full baskets of strawberries", new int[] {DWELLBERRY_SEED}));
+        add(builder, new PaymentPair("6 watermelons", new int[] {JANGERBERRY_SEED}));
+        add(builder, new PaymentPair("8 bittercap mushrooms", new int[] {WHITEBERRY_SEED}));
+        add(builder, new CustomPair("as it will never get diseased", new int[] {POISON_IVY_SEED}));
+        // TREE PAIRS
+        add(builder, new PaymentPair("1 full basket of tomatoes", new int[] {ACORN, OAK_SAPLING, OAK_SEEDLING, OAK_SEEDLING_W}, "oak tree"));
+        add(builder, new PaymentPair("1 full basket of apples", new int[] {WILLOW_SEED, WILLOW_SAPLING, WILLOW_SEEDLING, WILLOW_SEEDLING_W}, "willow tree"));
+        add(builder, new PaymentPair("1 full basket of oranges", new int[] {MAPLE_SEED, MAPLE_SAPLING, MAPLE_SEEDLING, MAPLE_SEEDLING_W}, "maple tree"));
+        add(builder, new PaymentPair("10 cactus spines", new int[] {YEW_SEED, YEW_SAPLING, YEW_SEEDLING, YEW_SEEDLING_W}, "yew tree"));
+        add(builder, new PaymentPair("25 coconuts", new int[] {MAGIC_SEED, MAGIC_SAPLING, MAGIC_SEEDLING, MAGIC_SEEDLING_W}, "magic tree"));
+        // FRUIT TREE PAIRS
+        add(builder, new PaymentPair("9 sweetcorn", new int[] {APPLE_TREE_SEED, APPLE_SAPLING, APPLE_SEEDLING, APPLE_SEEDLING_W}, "apple tree"));
+        add(builder, new PaymentPair("4 full baskets of apples", new int[] {BANANA_TREE_SEED, BANANA_SAPLING, BANANA_SEEDLING, BANANA_SEEDLING_W}, "banana tree"));
+        add(builder, new PaymentPair("3 full baskets of strawberries", new int[] {ORANGE_TREE_SEED, ORANGE_SAPLING, ORANGE_SEEDLING, ORANGE_SEEDLING_W}, "orange tree"));
+        add(builder, new PaymentPair("5 full baskets of bananas", new int[] {CURRY_TREE_SEED, CURRY_SAPLING, CURRY_SEEDLING, CURRY_SEEDLING_W}, "curry tree"));
+        add(builder, new PaymentPair("10 watermelons", new int[] {PINEAPPLE_SEED, PINEAPPLE_SAPLING, PINEAPPLE_SEEDLING, PINEAPPLE_SEEDLING_W}));
+        add(builder, new PaymentPair("10 pineapples", new int[] {PAPAYA_TREE_SEED, PAPAYA_SAPLING, PAPAYA_SEEDLING, PAPAYA_SEEDLING_W}, "papaya tree"));
+        add(builder, new PaymentPair("15 papaya fruit", new int[] {PALM_TREE_SEED, PALM_SAPLING, PALM_SEEDLING, PALM_SEEDLING_W}, "palm tree"));
+        add(builder, new PaymentPair("15 coconuts", new int[] {DRAGONFRUIT_TREE_SEED, DRAGONFRUIT_SAPLING, DRAGONFRUIT_SEEDLING, DRAGONFRUIT_SEEDLING_W}, "dragonfruit tree"));
+        // SPECIAL PAIRS
+        add(builder, new PaymentPair("200 numulite", new int[] {SEAWEED_SPORE}));
+        add(builder, new CustomPair("as it is protected for free. That doesn't make sense but I'm too lazy to change it", new int[] {GRAPE_SEED}));
+        add(builder, new CustomPair(new int[] {MUSHROOM_SPORE, BELLADONNA_SEED}));
+        add(builder, new CustomPair("as it is immune to disease", new int[] {HESPORI_SEED}));
+        // ANIMA PAIRS
+        add(builder, new CustomPair(new int[] {KRONOS_SEED, IASOR_SEED, ATTAS_SEED}));
+        // SPECIAL TREE PAIRS
+        add(builder, new PaymentPair("15 limpwurt roots", new int[] {TEAK_SEED, TEAK_SAPLING, TEAK_SEEDLING, TEAK_SEEDLING_W}, "teak tree"));
+        add(builder, new PaymentPair("25 yanillian hops", new int[] {MAHOGANY_SEED, MAHOGANY_SAPLING, MAHOGANY_SEEDLING, MAHOGANY_SEEDLING_W}, "mahogany tree"));
+        add(builder, new PaymentPair("8 poison ivy berries", new int[] {CALQUAT_TREE_SEED, CALQUAT_SAPLING, CALQUAT_SEEDLING, CALQUAT_SEEDLING_W}, "calquat tree"));
+        add(builder, new CustomPair("as it is immune to disease", new int[] {CRYSTAL_SEED, CRYSTAL_SAPLING, CRYSTAL_SEEDLING, CRYSTAL_SEEDLING_W}));
+        add(builder, new PaymentPair("5 monkey nuts, 1 monkey bar, and 1 ground tooth", new int[] {SPIRIT_SEED, SPIRIT_SAPLING, SPIRIT_SEEDLING, SPIRIT_SEEDLING_W}, "spirit tree"));
+        add(builder, new PaymentPair("8 potato cacti", new int[] {CELASTRUS_SEED, CELASTRUS_SAPLING, CELASTRUS_SEEDLING, CELASTRUS_SEEDLING_W}, "celastrus tree"));
+        add(builder, new PaymentPair("6 dragonfruit", new int[] {REDWOOD_TREE_SEED, REDWOOD_SAPLING, REDWOOD_SEEDLING, REDWOOD_SEEDLING_W}, "redwood tree"));
+        // CACTI PAIRS
+        add(builder, new PaymentPair("6 cadava berries", new int[] {CACTUS_SEED}));
+        add(builder, new PaymentPair("8 snape grass", new int[] {POTATO_CACTUS_SEED}));
+
+        payments = builder.build();
+    }
 
     @Inject
     @Nullable
@@ -167,64 +181,60 @@ public class PatchPaymentPlugin extends Plugin {
     @Subscribe
     public void onMenuOptionClicked(MenuOptionClicked event)
     {
-        if (event.getWidget() != null && config.checkWithExamine() && event.getMenuOption().equals("Examine") )
+        if (event.getWidget() != null
+                && config.checkWithExamine()
+                && event.getMenuOption().equals(EXAMINE))
         {
             final int widgetId = event.getWidget().getId();
 
             if(!acceptedWidgetIds.contains(widgetId)) return;
 
             ItemComposition composition = client.getItemDefinition(event.getWidget().getItemId());
+            int itemId = composition.getId();
 
-            for (PairInterface pp : paymentPairList)
-            {
-                if (pp.checkForId(composition.getId()))
-                {
-                    displayGameMessage(pp, composition);
-                }
-            }
+            if(payments.containsKey(itemId))
+                displayGameMessage(payments.get(itemId), composition);
+
         }
     }
 
     @Subscribe
     public void onMenuEntryAdded(MenuEntryAdded event)
     {
-        if (event.getMenuEntry().getWidget() != null && !config.checkWithExamine())
+        if (event.getMenuEntry().getWidget() != null
+                && !config.checkWithExamine()
+                && event.getOption().equals(EXAMINE))
         {
-            if (event.getOption().equals("Examine"))
+            if (!acceptedWidgetIds.contains(event.getMenuEntry().getWidget().getId()))
+                return;
+
+            int itemId = event.getMenuEntry().getWidget().getItemId();
+
+            if (payments.containsKey(itemId))
             {
-                if(!acceptedWidgetIds.contains(event.getMenuEntry().getWidget().getId()))
-                    return;
+                ItemComposition ic = client.getItemDefinition(itemId);
 
-                int itemid = event.getMenuEntry().getWidget().getItemId();
-
-                    for (PairInterface pp : paymentPairList)
-                    {
-                        if (pp.checkForId(itemid))
+                client.createMenuEntry(-1)
+                        .setOption(CHECK_PAYMENT)
+                        .setTarget(event.getTarget())
+                        .setType(MenuAction.RUNELITE)
+                        .onClick(e ->
                         {
-                            ItemComposition ic = client.getItemDefinition(itemid);
-
-                            client.createMenuEntry(-1)
-                                    .setOption(CHECK_PAYMENT)
-                                    .setTarget(event.getTarget())
-                                    .setType(MenuAction.RUNELITE)
-                                    .onClick(e -> { displayGameMessage(pp, ic); });
-
-                            return;
-                        }
-                }
+                            displayGameMessage(payments.get(itemId), ic);
+                        });
             }
+
         }
     }
 
     public interface PairInterface {
-        int[] pairedIDs = null;
 
-        boolean checkForId(int id);
+        int[] getTargetItems();
 
         String getMessage(ItemComposition ic);
     }
 
-    class PaymentPair implements PairInterface {
+    static class PaymentPair implements PairInterface {
         String payment;
         int[] pairedIDs;
         String preferredName = null;
@@ -239,12 +249,10 @@ public class PatchPaymentPlugin extends Plugin {
             this.preferredName = preferredName;
         }
 
-        public boolean checkForId(int id) {
-            for (int check : pairedIDs) {
-                if (check == id)
-                    return true;
-            }
-            return false;
+        @Override
+        public int[] getTargetItems()
+        {
+            return this.pairedIDs;
         }
 
         public String getMessage(ItemComposition ic) {
@@ -270,7 +278,7 @@ public class PatchPaymentPlugin extends Plugin {
         }
     }
 
-    private class CustomPair implements PairInterface {
+    private static class CustomPair implements PairInterface {
 
         String message = "";
         int[] pairedIDs;
@@ -285,17 +293,10 @@ public class PatchPaymentPlugin extends Plugin {
             this.pairedIDs = pairedIDs;
         }
 
-        public CustomPair(String message, int[] pairedIDs, String preferredName) {
-            this(message, pairedIDs);
-            this.preferredName = preferredName;
-        }
-
-        public boolean checkForId(int id) {
-            for (int check : pairedIDs) {
-                if (check == id)
-                    return true;
-            }
-            return false;
+        @Override
+        public int[] getTargetItems()
+        {
+            return this.pairedIDs;
         }
 
         public String getMessage(ItemComposition ic) {
@@ -323,7 +324,7 @@ public class PatchPaymentPlugin extends Plugin {
         }
     }
 
-    private String stripAndShrink(String text) {
+    private static String stripAndShrink(String text) {
         return text
                 .replace("seed", "")
                 .replace("sapling", "")
@@ -331,7 +332,7 @@ public class PatchPaymentPlugin extends Plugin {
                 .toLowerCase().trim();
     }
 
-    private String grammatify(String text) {
+    private static String grammatify(String text) {
         char[] vowels = {'a', 'e', 'i', 'o', 'u'};
         for (char vowel : vowels)
             if (text.toLowerCase().charAt(0) == vowel)

--- a/src/main/java/com/patchpayment/PatchPaymentPlugin.java
+++ b/src/main/java/com/patchpayment/PatchPaymentPlugin.java
@@ -1,31 +1,24 @@
 package com.patchpayment;
 
-import com.google.common.collect.ObjectArrays;
 import com.google.common.collect.Sets;
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.events.MenuEntryAdded;
-import net.runelite.api.events.MenuOpened;
 import net.runelite.api.events.MenuOptionClicked;
-import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageBuilder;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
-import net.runelite.client.menus.MenuManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.util.ColorUtil;
-import org.apache.commons.lang3.ArrayUtils;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import javax.inject.Provider;
-import java.awt.Color;
-import java.util.Arrays;
 import java.util.HashSet;
 
 import static net.runelite.api.ItemID.*;
@@ -116,6 +109,9 @@ public class PatchPaymentPlugin extends Plugin {
     @Inject
     @Nullable
     private Client client;
+
+    @Inject
+    private ChatMessageManager chatMessageManager;
     @Inject
     private PatchPaymentConfig config;
 
@@ -162,7 +158,10 @@ public class PatchPaymentPlugin extends Plugin {
 
     private void displayGameMessage(PairInterface pi, ItemComposition ic)
     {
-        client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", pi.getMessage(ic), null);
+        chatMessageManager.queue(QueuedMessage.builder()
+                        .type(ChatMessageType.CONSOLE)
+                        .runeLiteFormattedMessage(pi.getMessage(ic))
+                        .build());
     }
 
     @Subscribe
@@ -252,7 +251,18 @@ public class PatchPaymentPlugin extends Plugin {
             String text = ic.getName();
             if (getPreferredName() != null)
                 text = getPreferredName();
-            return String.format("A farmer will watch over %s %s patch for %s.", grammatify(text), stripAndShrink(text), this.payment);
+            return new ChatMessageBuilder()
+                    .append(ChatColorType.NORMAL)
+                    .append("A farmer will watch over ")
+                    .append(grammatify(text))
+                    .append(" ")
+                    .append(ChatColorType.HIGHLIGHT)
+                    .append(stripAndShrink(text))
+                    .append(ChatColorType.NORMAL)
+                    .append(" patch for ")
+                    .append(ChatColorType.HIGHLIGHT)
+                    .append(this.payment)
+                    .build();
         }
 
         public String getPreferredName() {
@@ -292,7 +302,20 @@ public class PatchPaymentPlugin extends Plugin {
             String text = ic.getName();
             if (getPreferredName() != null)
                 text = getPreferredName();
-            return String.format("%s %s patch can NOT be protected by a farmer%s.", grammatify(text).replace('a', 'A'), stripAndShrink(text), this.message);
+            return new ChatMessageBuilder()
+                    .append(ChatColorType.NORMAL)
+                    .append(grammatify(text).replace('a', 'A'))
+                    .append(" ")
+                    .append(ChatColorType.HIGHLIGHT)
+                    .append(stripAndShrink(text))
+                    .append(ChatColorType.NORMAL)
+                    .append(" patch can ")
+                    .append(ChatColorType.HIGHLIGHT)
+                    .append("NOT")
+                    .append(ChatColorType.NORMAL)
+                    .append(" be protected by a farmer")
+                    .append(this.message)
+                    .build();
         }
 
         public String getPreferredName() {


### PR DESCRIPTION
I've had issues with the plugin for a while, finally decided to do something about it.
For whatever reason check within the inventory was not working. Bank and Seed Vault functionality was fine.

The core problem seemed to be with how the item id's were being collected while in the inventory widget, there might have been some RuneLite api change that affected the behaviour. After taking a look at that I changed a few other things too. :P

- Item id's now fetched by checking widget rather than option params
- ChatMessageManager used to send a formatted response
- All data now stored in a Map, couldn't be assed to change the data structure but a Map is a bit more efficient than iterating over id's every time the options are rebuilt.
- Removed onMenuOpened, a couple unused methods and fields.